### PR TITLE
Make the database port configurable with the most common port as default

### DIFF
--- a/settings/settings.py
+++ b/settings/settings.py
@@ -108,7 +108,7 @@ DATABASES = OrderedDict([
         'USER': 'DATABASE_USER' in server_settings and server_settings['DATABASE_USER'] or 'postgres',
         'PASSWORD': 'DATABASE_PASSWORD' in server_settings and server_settings['DATABASE_PASSWORD'] or '',
         'HOST': "DATABASE_HOST" in server_settings and server_settings["DATABASE_HOST"] or 'localhost',
-        'PORT': server_settings.get("DATABASE_PORT", 5432),
+        'PORT': "DATABASE_PORT" in server_settings and server_settings["DATABASE_PORT"] or 5432,
         'NUMBER': 42
     }]
 ])

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -108,7 +108,7 @@ DATABASES = OrderedDict([
         'USER': 'DATABASE_USER' in server_settings and server_settings['DATABASE_USER'] or 'postgres',
         'PASSWORD': 'DATABASE_PASSWORD' in server_settings and server_settings['DATABASE_PASSWORD'] or '',
         'HOST': "DATABASE_HOST" in server_settings and server_settings["DATABASE_HOST"] or 'localhost',
-        'PORT': 5432,
+        'PORT': server_settings.get("DATABASE_PORT", 5432),
         'NUMBER': 42
     }]
 ])


### PR DESCRIPTION
## Context

* The port is currently not configurable for the database
* Some strange people (me included) run several postgres on their machine, or can't run it on the same port, but still would want to easily participate to the project :D