### PR TITLE
Add swagger documentation for the API

### DIFF
--- a/documentation/python_dependency.md
+++ b/documentation/python_dependency.md
@@ -52,3 +52,9 @@ Oauth toolkit for api auth
 https://github.com/korfuri/django-prometheus
 
 Used to provide django metrics for monitoring
+
+
+### django-rest-swagger
+https://github.com/marcgibbons/django-rest-swagger
+
+Used to generated automated documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ fuzzysearch==0.7.3
 django-prometheus==2.1.0
 
 drf_spectacular==0.17.2
+django-rest-swagger=2.2.0

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     'ml',
     'oauth2_provider',
     'rest_framework',
+    'rest_framework_swagger',
     'drf_spectacular'
 ]
 
@@ -84,10 +85,13 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'settings.urls'
 
+
+
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -198,7 +202,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '10000/hour',
         'user': '1000000/hour'
-    }
+    },
 }
 
 

--- a/settings/urls.py
+++ b/settings/urls.py
@@ -16,11 +16,20 @@ Including another URLconf
 from django.contrib import admin
 from django.http import HttpResponseForbidden
 from django.urls import path, include
+from drf_spectacular.views import SpectacularSwaggerView, SpectacularAPIView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('monitoring/', include('django_prometheus.urls')),
     path('o/applications/', HttpResponseForbidden, name="create_app"),  # block for create app in oauth (admin only)
     path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "docs/",
+        SpectacularSwaggerView.as_view(
+            template_name="swagger-ui.html", url_name="schema"
+        ),
+        name="swagger-ui",
+    ),
     path('', include("tournesol.urls")),
 ]

--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Swagger</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
+</head>
+
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script>
+        const ui = SwaggerUIBundle({
+            url: "{% url 'schema' %}",
+            dom_id: '#swagger-ui',
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIBundle.SwaggerUIStandalonePreset
+            ],
+            layout: "BaseLayout",
+            requestInterceptor: (request) => {
+                request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+                return request;
+            }
+        })
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
In order to visualise the API, this PR adds a swagger UI documentation / OpenAPI specification export on /docs & /schemas.
