### PR TITLE
Fix request format to add video to a rate later list

### DIFF
--- a/tournesol/tests/test_api_video_rate_later.py
+++ b/tournesol/tests/test_api_video_rate_later.py
@@ -124,7 +124,7 @@ class VideoRateLaterApi(TestCase):
         client = APIClient()
 
         user = User.objects.get(username=self._user)
-        data = {"video.video_id": Video.objects.get(name=self._others_video).video_id}
+        data = {"video": {"video_id": Video.objects.get(name=self._others_video).video_id}}
 
         client.force_authenticate(user=user)
 
@@ -143,7 +143,7 @@ class VideoRateLaterApi(TestCase):
         client = APIClient()
 
         user = User.objects.get(username=self._user)
-        data = {"video.video_id": Video.objects.get(name=self._users_video).video_id}
+        data = {"video": {"video_id": Video.objects.get(name=self._users_video).video_id}}
 
         client.force_authenticate(user=user)
 
@@ -163,7 +163,7 @@ class VideoRateLaterApi(TestCase):
 
         user = User.objects.get(username=self._user)
         other = User.objects.get(username=self._other)
-        data = {"video.video_id": Video.objects.get(name=self._users_video).video_id}
+        data = {"video": {"video_id": Video.objects.get(name=self._users_video).video_id}}
 
         client.force_authenticate(user=user)
 

--- a/tournesol/views/video_rate_later.py
+++ b/tournesol/views/video_rate_later.py
@@ -20,7 +20,7 @@ def verify_username(request, username):
 
 
 class VideoRateLaterList(
-    mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView
+    mixins.ListModelMixin, generics.GenericAPIView
 ):
     """
     List all videos of a user's rate later list, or add a video to the list.
@@ -55,11 +55,11 @@ class VideoRateLaterList(
         verify_username(request, kwargs["username"])
 
         try:
-            video = get_object_or_404(Video, video_id=request.data["video.video_id"])
+            video = get_object_or_404(Video, video_id=request.data["video"]["video_id"])
         except KeyError:
             return Response(
                 {
-                    "detail": "Required field video.video_id not fount.",
+                    "detail": "Required field video.video_id not found.",
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )


### PR DESCRIPTION
According to the serializers definitions, the correct JSON format is `{"video": {"video_id": "<id>"}}`.  
That's also what is expected by the generated API schema.

Required by https://github.com/tournesol-app/tournesol-frontend/pull/4