### PR TITLE
skip criterias with no data instead of failing

### DIFF
--- a/ml/core.py
+++ b/ml/core.py
@@ -77,6 +77,9 @@ def _set_licchavi(
     """
     # shape data
     one_crit_data = select_criteria(comparison_data, criteria)
+    if len(one_crit_data) == 0:  # if no data for selected criteria
+        logging.warning(f"No comparison for this criteria ({criteria})")
+        return None, None
     full_data = shape_data(one_crit_data)
     # set licchavi using data
     if resume:
@@ -181,16 +184,19 @@ def ml_run(
             fullpath, resume, verb, device,
             ground_truths, licchavi_class=licchavi_class
         )
-        # training and predicting
-        glob, loc, uncertainties = _train_predict(
-            licch, epochs, fullpath, save, verb, 
-            compute_uncertainty=compute_uncertainty
-        )
-        # putting in required shape for output
-        out_glob = format_out_glob(glob, criteria, uncertainties[0])
-        out_loc = format_out_loc(loc, users_ids, criteria, uncertainties[1])
-        glob_scores += out_glob
-        loc_scores += out_loc
+
+        if licch is not None:  # if not 0 data for selected criteria
+
+            # training and predicting
+            glob, loc, uncertainties = _train_predict(
+                licch, epochs, fullpath, save, verb,
+                compute_uncertainty=compute_uncertainty
+            )
+            # putting in required shape for output
+            out_glob = format_out_glob(glob, criteria, uncertainties[0])
+            out_loc = format_out_loc(loc, users_ids, criteria, uncertainties[1])
+            glob_scores += out_glob
+            loc_scores += out_loc
 
     logging.info(f'ml_run() total time : {round(time() - ml_run_time)}')
     if TOURNESOL_DEV:  # return more information in dev mode

--- a/ml/handle_data.py
+++ b/ml/handle_data.py
@@ -35,8 +35,6 @@ def select_criteria(comparison_data, crit):
     l_ratings = [
         comp for comp in comparison_data if (comp[3] == crit and comp[4] is not None)
     ]
-    if len(l_ratings) == 0:
-        logging.warning(f"No comparison for this criteria ({crit})")
     return l_ratings
 
 


### PR DESCRIPTION
Minor changes to train even if some criterias have no data.